### PR TITLE
Move the API classes and interfaces to a separate assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 [Bb]in/
 [Oo]bj/
 
+**/_releases/*
+
 # Visual Studio cache/options
 .vs/
 

--- a/IModTabSettingsApi/Events/OptionsChangedEventArgs.cs
+++ b/IModTabSettingsApi/Events/OptionsChangedEventArgs.cs
@@ -11,10 +11,12 @@ namespace ModSettingsTabApi.Events
     public class OptionsChangedEventArgs : EventArgs
     {
         public Dictionary<string, Value> Options;
+        public bool Reloaded { get; set; }
 
         public OptionsChangedEventArgs(Dictionary<string, Value> options)
         {
             Options = options;
+            Reloaded = false;
         }
     }
 }

--- a/IModTabSettingsApi/Events/OptionsChangedEventArgs.cs
+++ b/IModTabSettingsApi/Events/OptionsChangedEventArgs.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace ModSettingsTab.Events
+namespace ModSettingsTabApi.Events
 {
     public class Value
     {

--- a/IModTabSettingsApi/Framework/Interfaces/IModTabSettingsApi.cs
+++ b/IModTabSettingsApi/Framework/Interfaces/IModTabSettingsApi.cs
@@ -1,0 +1,7 @@
+﻿namespace ModSettingsTabApi.Framework.Interfaces
+{
+    public interface IModTabSettingsApi
+    {
+        ISettingsTabApi GetMod(string uniqueId);
+    }
+}

--- a/IModTabSettingsApi/Framework/Interfaces/ISettingsTabApi.cs
+++ b/IModTabSettingsApi/Framework/Interfaces/ISettingsTabApi.cs
@@ -1,7 +1,7 @@
 using System;
-using ModSettingsTab.Events;
+using ModSettingsTabApi.Events;
 
-namespace ModSettingsTab.Framework.Interfaces
+namespace ModSettingsTabApi.Framework.Interfaces
 {
     public interface ISettingsTabApi
     {

--- a/IModTabSettingsApi/ModSettingsTabApi.csproj
+++ b/IModTabSettingsApi/ModSettingsTabApi.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E6BB97FC-AFCF-4283-9CFB-AC30C0B5E56D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ModSettingsTabApi</RootNamespace>
+    <AssemblyName>ModSettingsTabApi</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Framework\Interfaces\IModTabSettingsApi.cs" />
+    <Compile Include="Framework\Interfaces\ISettingsTabApi.cs" />
+    <Compile Include="Events\OptionsChangedEventArgs.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/IModTabSettingsApi/Properties/AssemblyInfo.cs
+++ b/IModTabSettingsApi/Properties/AssemblyInfo.cs
@@ -1,0 +1,34 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ModSettingsTabApi")]
+[assembly: AssemblyDescription("API for ModSettingsTab")]
+[assembly: AssemblyCompany("GilarF")]
+[assembly: AssemblyProduct("Mod Settings Tab API")]
+[assembly: AssemblyCopyright("Copyright ©Gilar Fasulaki 2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e6bb97fc-afcf-4283-9cfb-ac30c0b5e56d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ModSettingsTab/Api.cs
+++ b/ModSettingsTab/Api.cs
@@ -1,12 +1,11 @@
 using System;
 using System.Collections.Generic;
-using ModSettingsTab.Events;
 using ModSettingsTab.Framework;
-using ModSettingsTab.Framework.Interfaces;
+using ModSettingsTabApi.Framework.Interfaces;
 
 namespace ModSettingsTab
 {
-    public class Api
+    public class Api : IModTabSettingsApi
     {
         internal readonly Dictionary<string,SettingsTabApi> ApiList = new Dictionary<string, SettingsTabApi>();
 

--- a/ModSettingsTab/Framework/Components/SmapiHeading.cs
+++ b/ModSettingsTab/Framework/Components/SmapiHeading.cs
@@ -41,7 +41,7 @@ namespace ModSettingsTab.Framework.Components
                 72, 1f, 0.1f);
             b.End();
             b.Begin(SpriteSortMode.FrontToBack, BlendState.NonPremultiplied, SamplerState.PointClamp,
-                null, null, null, new Matrix?());
+                null, null, null);
             b.Draw(Game1.mouseCursors,
                 new Rectangle(slotX + _boundsStar.X, slotY + _boundsStar.Y, _boundsStar.Width, _boundsStar.Height),
                 Star,

--- a/ModSettingsTab/Framework/SettingsTabApi.cs
+++ b/ModSettingsTab/Framework/SettingsTabApi.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using ModSettingsTab.Events;
-using ModSettingsTab.Framework.Interfaces;
+using ModSettingsTabApi.Events;
+using ModSettingsTabApi.Framework.Interfaces;
 
 namespace ModSettingsTab.Framework
 {

--- a/ModSettingsTab/Framework/SettingsTabApi.cs
+++ b/ModSettingsTab/Framework/SettingsTabApi.cs
@@ -9,9 +9,13 @@ namespace ModSettingsTab.Framework
     {
         public event EventHandler<OptionsChangedEventArgs> OptionsChanged;
 
-        public void Send(object sender,Dictionary<string, Value> options)
+        public bool Send(object sender,Dictionary<string, Value> options)
         {
-            OptionsChanged?.Invoke(sender, new OptionsChangedEventArgs(options));
+            var eventArgs = new OptionsChangedEventArgs(options);
+
+            OptionsChanged?.Invoke(sender, eventArgs);
+
+            return eventArgs.Reloaded;
         }
     }
 }

--- a/ModSettingsTab/Framework/StaticConfig.cs
+++ b/ModSettingsTab/Framework/StaticConfig.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Timers;
-using ModSettingsTab.Events;
+using ModSettingsTabApi.Events;
 using Newtonsoft.Json.Linq;
 using StardewModdingAPI;
 using StardewValley;

--- a/ModSettingsTab/Framework/StaticConfig.cs
+++ b/ModSettingsTab/Framework/StaticConfig.cs
@@ -64,9 +64,11 @@ namespace ModSettingsTab.Framework
                 {
                     using (var writer = File.CreateText(path))
                         await writer.WriteAsync(ToString());
-                    ModData.NeedReload = true;
+
                     if (ModData.Api.ApiList.ContainsKey(uniqueId))
-                        ModData.Api.ApiList[uniqueId].Send(_config, _changedValues);
+                        ModData.NeedReload = !ModData.Api.ApiList[uniqueId].Send(_config, _changedValues) || ModData.NeedReload;
+                    else
+                        ModData.NeedReload = true;
                     _changedValues.Clear();
                     if (ModData.Config.ShowSavingNotify) 
                         Game1.addHUDMessage(new HUDMessage(ModEntry.I18N.Get("StaticConfig.SuccessMessage"), 2));

--- a/ModSettingsTab/Menu/BaseOptionsModPage.cs
+++ b/ModSettingsTab/Menu/BaseOptionsModPage.cs
@@ -306,8 +306,7 @@ namespace ModSettingsTab.Menu
         public override void draw(SpriteBatch b)
         {
             b.End();
-            b.Begin(SpriteSortMode.FrontToBack, BlendState.NonPremultiplied, SamplerState.PointClamp,
-                null, null, null, new Matrix?());
+            b.Begin(SpriteSortMode.FrontToBack, BlendState.NonPremultiplied, SamplerState.PointClamp, null, null);
             for (var index = 0; index < _optionSlots.Count; ++index)
             {
                 if (_currentItemIndex >= 0 && _currentItemIndex + index < Options.Count)
@@ -316,8 +315,7 @@ namespace ModSettingsTab.Menu
             }
 
             b.End();
-            b.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, null,
-                null, null, new Matrix?());
+            b.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, null, null);
             if (!GameMenu.forcePreventClose)
             {
                 _upArrow.draw(b);

--- a/ModSettingsTab/Menu/OptionsPage.cs
+++ b/ModSettingsTab/Menu/OptionsPage.cs
@@ -318,15 +318,13 @@ namespace ModSettingsTab.Menu
                 sideTab.draw(b);
             if (ModData.NeedReload && ModData.Config.ShowReloadIcon) _reloadIndicator.draw(b);
             b.End();
-            b.Begin(SpriteSortMode.FrontToBack, BlendState.NonPremultiplied, SamplerState.PointClamp,
-                null, null, null, new Matrix?());
+            b.Begin(SpriteSortMode.FrontToBack, BlendState.NonPremultiplied, SamplerState.PointClamp, null, null);
             if (_currentTab < _sideTabs.Count)
                 _pagesCollections[_currentTab].draw(b);
             else
                 _favoritePagesCollections[_currentTab - _sideTabs.Count].draw(b);
             b.End();
-            b.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, null,
-                null, null, new Matrix?());
+            b.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, null, null);
             if (_hoverText.Equals(""))
                 return;
             drawHoverText(b, _hoverText, Game1.smallFont, 0, 0, _value);

--- a/ModSettingsTab/ModData.cs
+++ b/ModSettingsTab/ModData.cs
@@ -15,7 +15,7 @@ namespace ModSettingsTab
     {
         public const int Offset = 192;
 
-        public static bool NeedReload;
+        public static bool NeedReload = false;
 
         public static readonly Api Api;
 

--- a/ModSettingsTab/ModSettingsTab.csproj
+++ b/ModSettingsTab/ModSettingsTab.csproj
@@ -38,7 +38,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Api.cs" />
-    <Compile Include="Events\OptionsChangedEventArgs.cs" />
     <Compile Include="Framework\Components\FilterTextBox.cs" />
     <Compile Include="Framework\Components\OptionsCheckbox.cs" />
     <Compile Include="Framework\Components\OptionsDropDown.cs" />
@@ -66,7 +65,6 @@
     <Compile Include="Framework\Interfaces\IOptionPlusMinus.cs" />
     <Compile Include="Framework\Interfaces\IOptionSlider.cs" />
     <Compile Include="Framework\Interfaces\IOptionTextBox.cs" />
-    <Compile Include="Framework\Interfaces\ISettingsTabApi.cs" />
     <Compile Include="Framework\Mod.cs" />
     <Compile Include="Framework\ModList.cs" />
     <Compile Include="Framework\SettingsTabApi.cs" />
@@ -121,6 +119,12 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\IModTabSettingsApi\ModSettingsTabApi.csproj">
+      <Project>{e6bb97fc-afcf-4283-9cfb-ac30c0b5e56d}</Project>
+      <Name>ModSettingsTabApi</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />

--- a/ModSettingsTab/ModSettingsTab.csproj
+++ b/ModSettingsTab/ModSettingsTab.csproj
@@ -1,142 +1,140 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E3A5F6A2-73B1-4360-AECA-B82AE7074FB6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ModSettingsTab</RootNamespace>
+    <AssemblyName>ModSettingsTab</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <LangVersion>7.3</LangVersion>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <ModZipPath>_releases</ModZipPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Api.cs" />
+    <Compile Include="Events\OptionsChangedEventArgs.cs" />
+    <Compile Include="Framework\Components\FilterTextBox.cs" />
+    <Compile Include="Framework\Components\OptionsCheckbox.cs" />
+    <Compile Include="Framework\Components\OptionsDropDown.cs" />
+    <Compile Include="Framework\Components\OptionsElement.cs" />
+    <Compile Include="Framework\Components\OptionsHeading.cs" />
+    <Compile Include="Framework\Components\OptionsInputListener.cs" />
+    <Compile Include="Framework\Components\OptionsList.cs" />
+    <Compile Include="Framework\Components\OptionsPlusMinus.cs" />
+    <Compile Include="Framework\Components\OptionsSlider.cs" />
+    <Compile Include="Framework\Components\OptionsTextBox.cs" />
+    <Compile Include="Framework\Components\PopupTextBox.cs" />
+    <Compile Include="Framework\Components\SmapiHeading.cs" />
+    <Compile Include="Framework\Components\TextBox.cs" />
+    <Compile Include="Framework\FavoriteData.cs" />
+    <Compile Include="Framework\Helper.cs" />
+    <Compile Include="Framework\Integration\Param.cs" />
+    <Compile Include="Framework\Integration\I18N.cs" />
+    <Compile Include="Framework\Integration\ModIntegrationSettings.cs" />
+    <Compile Include="Framework\Integration\ParamType.cs" />
+    <Compile Include="Framework\Integration\SmapiIntegration.cs" />
+    <Compile Include="Framework\Interfaces\IModOption.cs" />
+    <Compile Include="Framework\Interfaces\IOptionCheckBox.cs" />
+    <Compile Include="Framework\Interfaces\IOptionDropDown.cs" />
+    <Compile Include="Framework\Interfaces\IOptionInputListener.cs" />
+    <Compile Include="Framework\Interfaces\IOptionPlusMinus.cs" />
+    <Compile Include="Framework\Interfaces\IOptionSlider.cs" />
+    <Compile Include="Framework\Interfaces\IOptionTextBox.cs" />
+    <Compile Include="Framework\Interfaces\ISettingsTabApi.cs" />
+    <Compile Include="Framework\Mod.cs" />
+    <Compile Include="Framework\ModList.cs" />
+    <Compile Include="Framework\SettingsTabApi.cs" />
+    <Compile Include="Framework\StaticConfig.cs" />
+    <Compile Include="Menu\BaseOptionsModPage.cs" />
+    <Compile Include="Menu\FavoriteOptionsModPage.cs" />
+    <Compile Include="Menu\OptionsPage.cs" />
+    <Compile Include="Menu\OptionsModPage.cs" />
+    <Compile Include="Menu\SmapiOptionsPage.cs" />
+    <Compile Include="ModData.cs" />
+    <Compile Include="ModEntry.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TabConfig.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="assets\Tabs.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="data\favorite.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="data\I9N\GilarF.ModSettingsTab.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="data\I9N\Pathoschild.DebugMode.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="data\I9N\SmapiIntegration.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="i18n\de.json" />
+    <Content Include="i18n\default.json" />
+    <Content Include="i18n\es.json" />
+    <Content Include="i18n\fr.json" />
+    <Content Include="i18n\hu.json" />
+    <Content Include="i18n\it.json" />
+    <Content Include="i18n\ja.json" />
+    <Content Include="i18n\ko.json" />
+    <Content Include="i18n\pt.json" />
+    <Content Include="i18n\ru.json" />
+    <Content Include="i18n\tr.json" />
+    <Content Include="i18n\zh.json" />
+    <Content Include="manifest.json" />
+    <Content Include="schema.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{E3A5F6A2-73B1-4360-AECA-B82AE7074FB6}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>ModSettingsTab</RootNamespace>
-        <AssemblyName>ModSettingsTab</AssemblyName>
-        <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-        <LangVersion>7.3</LangVersion>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <ModZipPath>_releases</ModZipPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-            <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-            <Private>True</Private>
-        </Reference>
-        <Reference Include="System" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Xml" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="Api.cs" />
-        <Compile Include="Events\OptionsChangedEventArgs.cs" />
-        <Compile Include="Framework\Components\FilterTextBox.cs" />
-        <Compile Include="Framework\Components\OptionsCheckbox.cs" />
-        <Compile Include="Framework\Components\OptionsDropDown.cs" />
-        <Compile Include="Framework\Components\OptionsElement.cs" />
-        <Compile Include="Framework\Components\OptionsHeading.cs" />
-        <Compile Include="Framework\Components\OptionsInputListener.cs" />
-        <Compile Include="Framework\Components\OptionsList.cs" />
-        <Compile Include="Framework\Components\OptionsPlusMinus.cs" />
-        <Compile Include="Framework\Components\OptionsSlider.cs" />
-        <Compile Include="Framework\Components\OptionsTextBox.cs" />
-        <Compile Include="Framework\Components\PopupTextBox.cs" />
-        <Compile Include="Framework\Components\SmapiHeading.cs" />
-        <Compile Include="Framework\Components\TextBox.cs" />
-        <Compile Include="Framework\FavoriteData.cs" />
-        <Compile Include="Framework\Helper.cs" />
-        <Compile Include="Framework\Integration\Param.cs" />
-        <Compile Include="Framework\Integration\I18N.cs" />
-        <Compile Include="Framework\Integration\ModIntegrationSettings.cs" />
-        <Compile Include="Framework\Integration\ParamType.cs" />
-        <Compile Include="Framework\Integration\SmapiIntegration.cs" />
-        <Compile Include="Framework\Interfaces\IModOption.cs" />
-        <Compile Include="Framework\Interfaces\IOptionCheckBox.cs" />
-        <Compile Include="Framework\Interfaces\IOptionDropDown.cs" />
-        <Compile Include="Framework\Interfaces\IOptionInputListener.cs" />
-        <Compile Include="Framework\Interfaces\IOptionPlusMinus.cs" />
-        <Compile Include="Framework\Interfaces\IOptionSlider.cs" />
-        <Compile Include="Framework\Interfaces\IOptionTextBox.cs" />
-        <Compile Include="Framework\Interfaces\ISettingsTabApi.cs" />
-        <Compile Include="Framework\Mod.cs" />
-        <Compile Include="Framework\ModList.cs" />
-        <Compile Include="Framework\SettingsTabApi.cs" />
-        <Compile Include="Framework\StaticConfig.cs" />
-        <Compile Include="Menu\BaseOptionsModPage.cs" />
-        <Compile Include="Menu\FavoriteOptionsModPage.cs" />
-        <Compile Include="Menu\OptionsPage.cs" />
-        <Compile Include="Menu\OptionsModPage.cs" />
-        <Compile Include="Menu\SmapiOptionsPage.cs" />
-        <Compile Include="ModData.cs" />
-        <Compile Include="ModEntry.cs" />
-        <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="TabConfig.cs" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Include="packages.config" />
-    </ItemGroup>    
-    <ItemGroup>
-        <Content Include="assets\Tabs.png" />
-        <Content Include="data\favorite.json">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </Content>
-        <Content Include="data\I9N\GilarF.ModSettingsTab.json">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </Content>
-        <Content Include="data\I9N\Pathoschild.DebugMode.json">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </Content>
-        <Content Include="data\I9N\SmapiIntegration.json">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </Content>
-        <Content Include="i18n\de.json" />
-        <Content Include="i18n\default.json" />
-        <Content Include="i18n\es.json" />
-        <Content Include="i18n\fr.json" />
-        <Content Include="i18n\hu.json" />
-        <Content Include="i18n\it.json" />
-        <Content Include="i18n\ja.json" />
-        <Content Include="i18n\ko.json" />
-        <Content Include="i18n\pt.json" />
-        <Content Include="i18n\ru.json" />
-        <Content Include="i18n\tr.json" />
-        <Content Include="i18n\zh.json" />
-      <Content Include="manifest.json" />
-      <Content Include="schema.json" />
-    </ItemGroup>
-    <ItemGroup>
-      <Folder Include="_releases" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-      <PropertyGroup>
-        <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
-      </PropertyGroup>
-      <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-    </Target>
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">
     </Target>
     <Target Name="AfterBuild">
     </Target>
     -->
-
 </Project>

--- a/ModSettingsTab/Properties/AssemblyInfo.cs
+++ b/ModSettingsTab/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyTitle("ModSettingsTab")]
+[assembly: AssemblyDescription("Replaces the standard options tab, adding the function of editing the settings of installed modifications")]
+[assembly: AssemblyCompany("GilarF")]
+[assembly: AssemblyProduct("Mod Settings Tab")]
+[assembly: AssemblyCopyright("Copyright ©Gilar Fasulaki 2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e3a5f6a2-73b1-4360-aeca-b82ae7074fb6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]

--- a/ModSettingsTab/packages.config
+++ b/ModSettingsTab/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452"/>
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
   <package id="Pathoschild.Stardew.ModBuildConfig" version="3.0.0" targetFramework="net452" />
 </packages>

--- a/SVM.sln
+++ b/SVM.sln
@@ -1,6 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModSettingsTab", "ModSettingsTab\ModSettingsTab.csproj", "{E3A5F6A2-73B1-4360-AECA-B82AE7074FB6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModSettingsTabApi", "IModTabSettingsApi\ModSettingsTabApi.csproj", "{E6BB97FC-AFCF-4283-9CFB-AC30C0B5E56D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -12,5 +17,15 @@ Global
 		{E3A5F6A2-73B1-4360-AECA-B82AE7074FB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E3A5F6A2-73B1-4360-AECA-B82AE7074FB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E3A5F6A2-73B1-4360-AECA-B82AE7074FB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6BB97FC-AFCF-4283-9CFB-AC30C0B5E56D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6BB97FC-AFCF-4283-9CFB-AC30C0B5E56D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6BB97FC-AFCF-4283-9CFB-AC30C0B5E56D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6BB97FC-AFCF-4283-9CFB-AC30C0B5E56D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AB76D2C0-A2A1-4B8B-A720-60187B75C715}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Moved the ISettingsTabApi interface and OptionsChangedEventArgs class to ModSettingsTabApi
Added the IModSettingsTabApi interface and added it as a base to Api
Fixed compilation errors

I have successfully integrated the API with my [own mod](https://github.com/Xebeth/StardewValley-SpeedMod) after these changes.
I think separating the API code will facilitate integration and adoption.

See [Issue #687](https://github.com/Pathoschild/SMAPI/issues/687) on the SMAPI repo for the reason of this change.